### PR TITLE
fix: Fixed Backend on relflecting what slot# the user recently parked

### DIFF
--- a/frontend/src/pages/dashboard/StaffDashboard.jsx
+++ b/frontend/src/pages/dashboard/StaffDashboard.jsx
@@ -121,7 +121,7 @@ const StaffDashboard = ({ currentUser }) => {
           return {
             date: entryTime.toISOString().split('T')[0],
             timeIn: entryTime.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true }),
-            slot: record.parkingSlot?.location || 'N/A',
+            slot: record.slotLocation || 'N/A',
             status: status
           };
         })

--- a/frontend/src/pages/dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/dashboard/StudentDashboard.jsx
@@ -101,7 +101,7 @@ const StudentDashboard = ({ currentUser }) => {
           return {
             date: entryTime.toISOString().split('T')[0],
             timeIn: entryTime.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true }),
-            slot: record.parkingSlot?.location || 'N/A',
+            slot: record.slotLocation || 'N/A',
             status: status
           };
         })


### PR DESCRIPTION
This pull request updates how parking slot information is accessed in both the staff and student dashboard components. The change ensures that the slot location is consistently retrieved from `record.slotLocation` instead of the nested `record.parkingSlot?.location` property.

Dashboard data consistency:

* Updated the `StaffDashboard` component to use `record.slotLocation` for displaying parking slot information, improving reliability and consistency.
* Updated the `StudentDashboard` component to use `record.slotLocation` for displaying parking slot information, matching the approach used in the staff dashboard.